### PR TITLE
Add Support for Array in get Request

### DIFF
--- a/packages/viur-vue-utils/utils/request.js
+++ b/packages/viur-vue-utils/utils/request.js
@@ -238,7 +238,22 @@ class cachedFetch {
         function buildGetUrl(url, params) {
             let requestUrl = new URL(url)
             if (params && Object.keys(params).length > 0) {
-                requestUrl.search = new URLSearchParams(params).toString();
+				const urlparams=  new URLSearchParams()
+				for (const [key, value] of Object.entries(params)) {
+					if(Array.isArray(value))
+					{
+						for (const v of value)
+						{
+							urlparams.append(key,v);
+						}
+					}
+					else
+					{
+						urlparams.append(key,value);
+					}
+				}
+
+                requestUrl.search = urlparams.toString();
             }
 
             return requestUrl.toString()


### PR DESCRIPTION
This PR support that we can now use Arrays in queries.
e.g. : I need to filter an list with an select multiple bone than we can now send 
`http://localhost:8080/json/test/list?testSelectmul=b&testSelectmul=a` instead of 
`http://localhost:8080/json/test/list?testSelectmul=%5Ba%2Cb%5D`