### PR TITLE
fix: `fetchAll` and make it async

### DIFF
--- a/src/utils/handlers.js
+++ b/src/utils/handlers.js
@@ -159,15 +159,13 @@ export function ListRequest(
      * fetch all Entries till cursor ends
      * WARNING dont do this with large lists
      */
-    function fetchAll(do_reset = true) {
+    async function fetchAll(do_reset = true) {
       if (do_reset) reset()
-      let nextRequest = next()
+      const nextRequest = await next()
       if (nextRequest === 0) {
         return 0
       }
-      return nextRequest.then((resp) => {
-        fetchAll(false)
-      })
+      await fetchAll(false)
     }
 
     /**


### PR DESCRIPTION
This PR fix the `fetchAll` Function. 
The problem was if you had code like:
```js
const params = {"foo": bar,limit:5}
const storeName = "dpliststore_" + state.skel.key 
const dpList = ListRequest(storeName, {
    module: "foo",
    params: params
  })
await dpList.fetchAll()
const data = dpList.state,skellist;
```
The skellist has max 30 entries because the `fetchAll` fuction not await the other requests before returning.