### PR TITLE
feat: Add captchaBone and beforeSend hook to ViForm

### DIFF
--- a/src/bones/edit/default/captchaBone.vue
+++ b/src/bones/edit/default/captchaBone.vue
@@ -1,0 +1,70 @@
+<template>
+  <div ref="container"></div>
+  <input :value="state.token" required class="is-hidden">
+</template>
+
+<script setup>
+import {reactive, onMounted, inject, ref} from "vue"
+import {load} from "recaptcha-v3";
+
+const container = ref(null);
+defineOptions({
+  inheritAttrs: false,
+})
+const props = defineProps({
+  name: String,
+  value: [Object, String, Number, Boolean, Array],
+  index: Number,
+  lang: String,
+  bone: Object,
+  autofocus: Boolean,
+})
+
+const emit = defineEmits(["change"])
+
+const formState = inject("formState")
+const state = reactive({
+  recaptchaInstance: null,
+  token: null,
+})
+
+async function getToken() {
+  state.token = await state.recaptchaInstance.execute(props.bone.action)
+  emit("change", props.name, state.token, props.lang, props.index)
+
+}
+
+onMounted(async () => {
+  const options = {
+    useEnterprise: true,
+    autoHideBadge: true,
+  }
+  if (props.bone.render_challenge) {
+    options["explicitRenderParameters"] = {
+      action: props.bone.action,
+      container: container.value,
+      callback: (token) => {
+        state.token = token
+        emit("change", props.name, token, props.lang, props.index, true)
+      },
+      "expired-callback": () => {
+        state.token = null
+        emit("change", props.name, null, props.lang, props.index, false)
+      },
+    }
+  }
+  state.recaptchaInstance = await load(props.bone.public_key, options)
+
+  if (formState && !props.bone.render_challenge) {
+    formState.beforeSend.push(getToken)
+  }
+  emit("change", props.name, null, props.lang, props.index, false) //init
+})
+
+</script>
+
+<style scoped>
+.is-hidden {
+  display: none;
+}
+</style>

--- a/src/bones/edit/index.js
+++ b/src/bones/edit/index.js
@@ -16,6 +16,7 @@ import fileBone from "./default/fileBone.vue"
 import textBone from "./default/textBone.vue"
 import spatialBone from "./default/spatialBone.vue"
 import codeBone from "./default/codeBone.vue"
+import captchaBone from "./default/captchaBone.vue"
 
 import booleanBoneSelect from "./default/booleanBoneSelect.vue"
 import booleanBoneChoose from "./default/booleanBoneChoose.vue"
@@ -25,6 +26,7 @@ import relationalBoneSelect from "./default/relationalBoneSelect.vue"
 import defaultBar from "./actionbar/defaultBar.vue"
 import relationalBar from "./actionbar/relationalBar.vue"
 import fileBar from "./actionbar/fileBar.vue"
+
 
 import { reactive, shallowRef } from "vue"
 import { defineStore } from "pinia"
@@ -55,6 +57,7 @@ export const useBoneStore = defineStore("boneStore", () => {
       selectBoneChoose,
       relationalBoneSelect,
       codeBone,
+      captchaBone,
     }),
     actionbars: shallowRef({
       "relational.tree.leaf.file.file": fileBar,
@@ -136,6 +139,8 @@ export const useBoneStore = defineStore("boneStore", () => {
       return textBone
     } else if (boneType === "spatial" || boneType.startsWith("spatial.")) {
       return spatialBone
+    } else if (boneType === "captcha") {
+      return captchaBone
     }
 
     return rawBone

--- a/src/forms/ViForm.vue
+++ b/src/forms/ViForm.vue
@@ -183,6 +183,7 @@ const state = reactive({
   readonly: computed(() => props.readonly),
   categoryDefaultname: computed(() => props.categoryDefaultname),
   failed: null,
+  beforeSend: [],
 })
 provide("formState", state)
 if (!props.internal) {

--- a/src/forms/utils.js
+++ b/src/forms/utils.js
@@ -118,7 +118,7 @@ export function useFormUtils(props, state) {
     return formdata
   }
 
-  function sendData(alternativUrl = null, additionalData = null, headers = null, removeKeyFromDataset = true) {
+  async function sendData(alternativUrl = null, additionalData = null, headers = null, removeKeyFromDataset = true) {
     state.loading = true
     let isValid = state.viformelement.reportValidity()
     if (!isValid) {
@@ -131,7 +131,9 @@ export function useFormUtils(props, state) {
 
     let url = buildRequestUrl()
     if (alternativUrl) url = alternativUrl //replace saving url
-
+    for (const hook of state.beforeSend) {
+      await hook()
+    }
     const formData = new FormData()
     for (const bone of toFormData()) {
       for (const [k, v] of Object.entries(bone)) {
@@ -151,6 +153,8 @@ export function useFormUtils(props, state) {
     if (additionalData) {
       data = { ...data, ...additionalData } //inject data like contexts
     }
+
+
 
     return request(url, { dataObj: data, headers: headers }).then(async (resp) => {
       let data = await resp.clone().json()

--- a/src/package.json
+++ b/src/package.json
@@ -41,6 +41,7 @@
     "vue-draggable-plus": "^0.6.0",
     "vue-i18n": "^11.0.1",
     "vue-json-pretty": "^2.4.0",
+    "recaptcha-v3": "^1.9.0",
     "vue-router": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
  Add a captchaBone component with reCAPTCHA Enterprise support (invisible
  and checkbox widget mode via render_challenge). Add a beforeSend hook
  array to ViForm state so bones can register async callbacks that run
  before sendData fires.
  For: https://github.com/viur-framework/viur-core/pull/1680