### PR TITLE
perf(bones): lazy-load default textBone (CKEditor)

### DIFF
--- a/src/bones/edit/index.js
+++ b/src/bones/edit/index.js
@@ -13,7 +13,6 @@ import numericBone from "./default/numericBone.vue"
 import relationalBone from "./default/relationalBone.vue"
 import jsonBone from "./default/jsonBone.vue"
 import fileBone from "./default/fileBone.vue"
-import textBone from "./default/textBone.vue"
 import spatialBone from "./default/spatialBone.vue"
 import codeBone from "./default/codeBone.vue"
 
@@ -26,8 +25,13 @@ import defaultBar from "./actionbar/defaultBar.vue"
 import relationalBar from "./actionbar/relationalBar.vue"
 import fileBar from "./actionbar/fileBar.vue"
 
-import { reactive, shallowRef } from "vue"
+import { reactive, shallowRef, defineAsyncComponent } from "vue"
 import { defineStore } from "pinia"
+
+// textBone pulls in CKEditor, which is large (~hundreds of kB). Load it lazily so
+// CKEditor is only fetched when a CKEditor-based text widget is actually rendered.
+// Projects that register their own "text" widget never load CKEditor at all.
+const textBone = defineAsyncComponent(() => import("./default/textBone.vue"))
 
 export const useBoneStore = defineStore("boneStore", () => {
   const state = reactive({


### PR DESCRIPTION
## Summary
The default text-bone widget (`bones/edit/default/textBone.vue`) pulls in CKEditor. It is
**statically imported** in `bones/edit/index.js`, so CKEditor is bundled by **every** consuming
app — even apps that register their own `"text"` widget and never render CKEditor.

This PR loads it via `defineAsyncComponent(() => import("./default/textBone.vue"))`, so bundlers
can split CKEditor into a separate chunk that is only fetched when a CKEditor-based text widget is
actually rendered.

## Why this matters
- **Browser bundle:** CKEditor is ~900 kB and, in a real consuming app, made up roughly a third of
  the main JS bundle although it was never shown.
- **Install footprint:** the CKEditor packages (`ckeditor5` + ~60 `@ckeditor/*`) are
  **over 150 MB of `node_modules` in every project** that depends on vue-utils — a large cost for a
  widget that is frequently overridden/unused.

## Verification
Built a consuming app with code-splitting enabled: CKEditor moves into its own lazy chunk
(~926 kB) and **drops out of the main bundle**. Apps that override the `"text"` widget never load
that chunk at all. No functional change other than the CKEditor text widget now mounting
asynchronously.

## Notes
- No version bump — left to the maintainer.
- This addresses the **runtime bundle**. Fully removing the **install** footprint would be a
  separate step (e.g. making `ckeditor5`/`@ckeditor/ckeditor5-vue` an optional/peer dependency).
- Consuming apps only see the bundle win if they allow code-splitting (i.e. not forcing
  `inlineDynamicImports`).
